### PR TITLE
Set up hooks for boilerplates

### DIFF
--- a/baker/generators/base.js
+++ b/baker/generators/base.js
@@ -14,6 +14,12 @@ module.exports = yeoman.Base.extend({
   constructor(...args) {
     yeoman.Base.apply(this, args);
 
+    // eslint-disable-next-line global-require
+    const boilerplates = require('./boilerplates');
+    this.runBoilerplateHook = boilerplates.runBoilerplateHook;
+    this.runBoilerplateBeforeHook = boilerplates.runBoilerplateBeforeHook;
+    this.runBoilerplateAfterHook = boilerplates.runBoilerplateAfterHook;
+
     this.appDirectory = 'app';
     this.platforms = ['ios', 'android'];
     this.namingConventions = namingConventions;

--- a/baker/generators/boilerplates.js
+++ b/baker/generators/boilerplates.js
@@ -1,0 +1,30 @@
+module.exports = {
+  runBoilerplateHook(boilerplate, hookType) {
+    try {
+      const hookModuleLocation = this.templatePath(`./boilerplates/${boilerplate}__hook.js`);
+      // eslint-disable-next-line global-require
+      const moduleHook = require(hookModuleLocation);
+
+      switch (hookType) {
+        case 'before':
+          moduleHook.before(this);
+          break;
+        case 'after':
+          moduleHook.after(this);
+          break;
+        default:
+          throw new Error('Invalid hook type', hookType);
+      }
+    } catch (e) {
+      // console.log(`This boilerplate does not seem to have ${hookType} hook defined`, e);
+    }
+  },
+
+  runBoilerplateBeforeHook(boilerplate) {
+    this.runBoilerplateHook(boilerplate, 'before');
+  },
+
+  runBoilerplateAfterHook(boilerplate) {
+    this.runBoilerplateHook(boilerplate, 'after');
+  },
+};

--- a/baker/generators/component/index.js
+++ b/baker/generators/component/index.js
@@ -132,6 +132,8 @@ module.exports = BaseGenerator.extend({
           `${this.appDirectory}/components/${this.componentName}/${this._dropHBSExtension(f)}`);
       });
 
+      this.runBoilerplateBeforeHook(this.boilerplateName);
+
       if (this.platformSpecific) {
         this.platforms.forEach(platform => {
           const path = `${this.appDirectory}/components/${this.componentName}/index.${platform}.js`;
@@ -149,6 +151,8 @@ module.exports = BaseGenerator.extend({
           })
         );
       }
+
+      this.runBoilerplateAfterHook(this.boilerplateName);
     },
   },
 });

--- a/baker/generators/reducer/index.js
+++ b/baker/generators/reducer/index.js
@@ -29,16 +29,18 @@ module.exports = BaseGenerator.extend({
     },
 
     boilerplate() {
-      if (this.boilerplateName) {
-        this.boilerplate = this._renderBoilerplate(this.boilerplateName);
-      }
+      this.boilerplate = this._renderBoilerplate(this.boilerplateName);
     },
   },
 
   writing: {
     everything() {
+      this.runBoilerplateBeforeHook(this.boilerplateName);
+
       this.files.forEach(f => this.template(f,
         `${this.appDirectory}/components/${this.container}/${this._dropHBSExtension(f)}`));
+
+      this.runBoilerplateAfterHook(this.boilerplateName);
     },
 
     updateRootReducersModule() {

--- a/baker/generators/test/tests/navigation.js
+++ b/baker/generators/test/tests/navigation.js
@@ -20,7 +20,9 @@ describe('generator-rn:navigation', () => {
         componentName,
         boilerplateName,
       })
-      .on('ready', generator => { _generator = generator; })
+      .on('ready', generator => {
+        _generator = generator;
+      })
       .on('end', done);
   });
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build-android": "node node_modules/react-native/local-cli/cli.js bundle --entry-file index.android.js --bundle-output iOS/main.jsbundle --platform \"android\" --assets-dest ./  --dev false --reset-cache",
     "lint": "./node_modules/.bin/eslint app baker",
     "test:baker": "./node_modules/mocha/bin/mocha ./baker/generators/test/tests/**/*.js -R spec -r baker/generators/test/setup",
-    "ci": "npm run test:baker && ./node_modules/babel-cli/bin/babel-node.js --presets es2015 ./baker/ci/run-tests.js" 
+    "ci": "npm run test:baker && ./node_modules/babel-cli/bin/babel-node.js --presets es2015 ./baker/ci/run-tests.js"
   },
   "devDependencies": {
     "babel-cli": "^6.10.1",
@@ -35,6 +35,7 @@
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "mocha": "^2.5.3",
+    "mockery": "^1.7.0",
     "remote-redux-devtools": "^0.3.3",
     "shelljs": "^0.6.0",
     "sinon": "^1.17.4",


### PR DESCRIPTION
This adds support for hooks in boilerplates. To create a hook associated with a given boilerplate you need to create a js module sitting next to the boilerplate file and having the following name <boilerplatename>__hook.js and it should look as follows:

``` javascript
module.exports = {
   before(generator) {
     // runs before boilerplate is rendered
     // generator is an instance of Yeoman generator
   },
  after(generator) {
    // runs after boilerplate is rendered
    // generator is an instance of Yeoman generator
  },
}
```

For example, assuming there is a component boilerplate called **Map.js.hbs**. To define a hook for installing a 3rd party npm module associated with this map, create a file called **Map__hook.js** with the following code:

``` javascript
module.exports = {
  after(generator) {
    generator.spawnCommandSync('npm', [
      'install',
      '--save',
      'map-package',
    ]);
  }
};
```
